### PR TITLE
Added upper limit to Biopython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(name = 'PeptideBuilder',
     download_url = 'https://github.com/mtien/PeptideBuilder/archive/v1.0.4.tar.gz',
     platforms = 'Tested on Mac OS X and Windows 10',
     packages = ['PeptideBuilder'],
-    install_requires=['Biopython']
+    install_requires=['Biopython<=1.71.0']
 )


### PR DESCRIPTION
Doesn't work with the latest biopython version (1.76) due to issues importing `bio.PDB.Vector`, not 100% sure how to fix those without breaking something else, but I think putting and upper limit of the biopython would help for now (1.71.0 is the latest version I found that works).