### PR TITLE
Replace Pathlib with os to fix write issues

### DIFF
--- a/PeptideBuilder/PeptideBuilder.py
+++ b/PeptideBuilder/PeptideBuilder.py
@@ -1455,7 +1455,7 @@ def make_structure_from_geos(geos: List[Geo]) -> Structure:
 def add_terminal_OXT(structure: Structure, C_OXT_length: float = 1.23) -> Structure:
     """Adds a terminal oxygen atom ('OXT') to the last residue of chain A model 0 of the given structure, and returns the new structure. The OXT atom object will be contained in the last residue object of the structure.
 
-This function should be used only when the structure object is completed and no further residues need to be appended."""
+    This function should be used only when the structure object is completed and no further residues need to be appended."""
 
     rad = 180.0 / math.pi
 

--- a/examples/evaluation.py
+++ b/examples/evaluation.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import os
 import math
 
 from Bio.PDB import PDBIO
@@ -38,7 +38,7 @@ PDBdir = "PDBs"
 
 def build_linear_model(pdb_filename):
     parser = PDBParser()
-    structure = parser.get_structure("sample", Path(PDBdir, pdb_filename))
+    structure = parser.get_structure("sample", os.path.join(PDBdir, pdb_filename))
     model = structure[0]
     chain = model["A"]
     model_structure_geo = []
@@ -58,13 +58,13 @@ def build_linear_model(pdb_filename):
 def make_pdb_file(struct, file_nom):
     outfile = PDBIO()
     outfile.set_structure(struct)
-    outfile.save(Path(PDBdir, file_nom))
+    outfile.save(os.path.join(PDBdir, file_nom))
     return file_nom
 
 
 def build_backbone_model(pdb_filename):
     parser = PDBParser()
-    structure = parser.get_structure("sample", Path(PDBdir, pdb_filename))
+    structure = parser.get_structure("sample", os.path.join(PDBdir, pdb_filename))
     model = structure[0]
     chain = model["A"]
     model_structure_geo = []
@@ -134,7 +134,7 @@ def build_backbone_model(pdb_filename):
 
 def build_all_angles_model(pdb_filename):
     parser = PDBParser()
-    structure = parser.get_structure("sample", Path(PDBdir, pdb_filename))
+    structure = parser.get_structure("sample", os.path.join(PDBdir, pdb_filename))
     model = structure[0]
     chain = model["A"]
     model_structure_geo = []
@@ -192,7 +192,7 @@ def build_all_angles_model(pdb_filename):
 
 def build_phi_psi_model(pdb_filename):
     parser = PDBParser()
-    structure = parser.get_structure("sample", Path(PDBdir, pdb_filename))
+    structure = parser.get_structure("sample", os.path.join(PDBdir, pdb_filename))
     model = structure[0]
     chain = model["A"]
     seq = ""
@@ -244,8 +244,8 @@ def build_phi_psi_model(pdb_filename):
 def compare_structure(reference, alternate):
     parser = PDBParser()
 
-    ref_struct = parser.get_structure("Reference", Path(PDBdir, reference))
-    alt_struct = parser.get_structure("Alternate", Path(PDBdir, alternate))
+    ref_struct = parser.get_structure("Reference", os.path.join(PDBdir, reference))
+    alt_struct = parser.get_structure("Alternate", os.path.join(PDBdir, alternate))
 
     ref_model = ref_struct[0]
     ref_chain = ref_model["A"]

--- a/examples/evaluation.py
+++ b/examples/evaluation.py
@@ -321,24 +321,21 @@ def test_PeptideBuilder(pdb_code):
     RMS_all_angles_50, RMS_all_angles_150, RMS_all_angles, size = compare_structure(
         pdb_file, make_pdb_file(structure_all_angles, "AllAngles_" + pdb_file)
     )
-    output_line = (
-        "%s\t%i\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\n"
-        % (
-            pdb_code,
-            size,
-            RMS_phi_psi_50,
-            RMS_phi_psi_150,
-            RMS_phi_psi,
-            RMS_omega_50,
-            RMS_omega_150,
-            RMS_omega,
-            RMS_all_angles_50,
-            RMS_all_angles_150,
-            RMS_all_angles,
-            RMS_backbone_50,
-            RMS_backbone_150,
-            RMS_backbone,
-        )
+    output_line = "%s\t%i\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\t%0.1f\n" % (
+        pdb_code,
+        size,
+        RMS_phi_psi_50,
+        RMS_phi_psi_150,
+        RMS_phi_psi,
+        RMS_omega_50,
+        RMS_omega_150,
+        RMS_omega,
+        RMS_all_angles_50,
+        RMS_all_angles_150,
+        RMS_all_angles,
+        RMS_backbone_50,
+        RMS_backbone_150,
+        RMS_backbone,
     )
     return output_line
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setup(
     platforms="Tested on Mac OS X and Windows 10",
     packages=["PeptideBuilder"],
     install_requires=INSTALL_REQUIRES,
-    extras_require={"test": TEST_REQUIRES + INSTALL_REQUIRES,},
+    extras_require={
+        "test": TEST_REQUIRES + INSTALL_REQUIRES,
+    },
     classifiers=[
         # Trove classifiers
         # (https://pypi.python.org/pypi?%3Aaction=list_classifiers)


### PR DESCRIPTION
Currently, the `evaluation.py` file fails with:

```
$ python3 evaluation.py 
1aq7
/usr/lib/python3/dist-packages/Bio/PDB/PDBParser.py:395: PDBConstructionWarning: Ignoring unrecognized record 'TER' at line 1630
  warnings.warn(
/usr/lib/python3/dist-packages/Bio/PDB/PDBParser.py:395: PDBConstructionWarning: Ignoring unrecognized record 'TER' at line 1630
  warnings.warn(
/usr/lib/python3/dist-packages/Bio/PDB/PDBParser.py:395: PDBConstructionWarning: Ignoring unrecognized record 'TER' at line 1630
  warnings.warn(
Traceback (most recent call last):
  File "/home/nilesh/ups/PeptideBuilder/examples/evaluation.py", line 365, in <module>
    f_out.write(test_PeptideBuilder(i))
  File "/home/nilesh/ups/PeptideBuilder/examples/evaluation.py", line 313, in test_PeptideBuilder
    pdb_file, make_pdb_file(structure_backbone, "Backbone_" + pdb_file)
  File "/home/nilesh/ups/PeptideBuilder/examples/evaluation.py", line 61, in make_pdb_file
    outfile.save(Path(PDBdir, file_nom))
  File "/usr/lib/python3/dist-packages/Bio/PDB/PDBIO.py", line 380, in save
    fp.write(s)
AttributeError: 'PosixPath' object has no attribute 'write'
```
Biopython version: 1.78

This is an attempt to fix the problem, avoiding the use of POSIX path.